### PR TITLE
Snowflake (snowsql) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ SQLTools will save you (for sure) a lot of time and help you to increase your pr
 
 ## Features
 
-* Works with PostgreSQL, MySQL, Oracle, MSSQL, SQLite, Vertica, Firebird
+* Works with PostgreSQL, MySQL, Oracle, MSSQL, SQLite, Vertica, Firebird, and Snowflake
 * Smart completions (except SQLite)
 * Run SQL Queries &nbsp; <kbd>CTRL+e</kbd>, <kbd>CTRL+e</kbd>
 ![Auto complete and run SQL queries](https://github.com/mtxr/SQLTools/raw/images/execute_auto_complete.gif?raw=true)

--- a/SQLTools.sublime-settings
+++ b/SQLTools.sublime-settings
@@ -15,7 +15,8 @@
         "sqlite"  : "sqlite3",
         "vertica" : "vsql",
         "firebird": "isql",
-        "sqsh"    : "sqsh"
+        "sqsh"    : "sqsh",
+        "snowsql" : "snowsql"
     },
 
     // If there is no SQL selected, use "expanded" region.
@@ -509,6 +510,36 @@
                     "query": "select top {1} * from \"{0}\";",
                     "options": [],
                     "before": ["\\set semicolon_cmd=\"\\go -mpretty -l\""]
+                }
+            }
+        },
+
+        "snowsql": {
+            "options": [],
+            "args": "-u {user} -a {account} -d {database} --authenticator {auth} -K",
+            "queries": {
+                "execute": {
+                    "options": [],
+                },
+                "show records": {
+                    "query": "SELECT * FROM {0} LIMIT {1};"
+                },
+                "desc table": {
+                    "query": "DESC TABLE {0};",
+                    "options": ["-o", "output_format=plain", 
+                                "-o", "timing=False"]
+                },
+                "desc": {
+                    "query": "SELECT TABLE_SCHEMA || '.' || TABLE_NAME AS tbl FROM INFORMATION_SCHEMA.TABLES;",
+                    "options": ["-o", "output_format=plain", 
+                                "-o", "header=False", 
+                                "-o", "timing=False"]
+                },
+                "columns": {
+                    "query": "SELECT TABLE_NAME || '.' || COLUMN_NAME AS col FROM INFORMATION_SCHEMA.COLUMNS",
+                    "options": ["-o", "output_format=plain", 
+                                "-o", "header=False", 
+                                "-o", "timing=False"]
                 }
             }
         }

--- a/SQLTools.sublime-settings
+++ b/SQLTools.sublime-settings
@@ -516,6 +516,9 @@
 
         "snowsql": {
             "options": [],
+            "env_optional": {
+                "SNOWSQL_PWD": "{password}"
+            },
             "args": "-u {user} -a {account} -d {database} --authenticator {auth} -K",
             "queries": {
                 "execute": {

--- a/SQLTools.sublime-settings
+++ b/SQLTools.sublime-settings
@@ -530,13 +530,13 @@
                                 "-o", "timing=False"]
                 },
                 "desc": {
-                    "query": "SELECT TABLE_SCHEMA || '.' || TABLE_NAME AS tbl FROM INFORMATION_SCHEMA.TABLES;",
+                    "query": "SELECT TABLE_SCHEMA || '.' || TABLE_NAME AS tbl FROM INFORMATION_SCHEMA.TABLES ORDER BY tbl;",
                     "options": ["-o", "output_format=plain", 
                                 "-o", "header=False", 
                                 "-o", "timing=False"]
                 },
                 "columns": {
-                    "query": "SELECT TABLE_NAME || '.' || COLUMN_NAME AS col FROM INFORMATION_SCHEMA.COLUMNS",
+                    "query": "SELECT TABLE_NAME || '.' || COLUMN_NAME AS col FROM INFORMATION_SCHEMA.COLUMNS ORDER BY col;",
                     "options": ["-o", "output_format=plain", 
                                 "-o", "header=False", 
                                 "-o", "timing=False"]

--- a/SQLToolsConnections.sublime-settings
+++ b/SQLToolsConnections.sublime-settings
@@ -92,6 +92,7 @@
       "account" : "account_name",
       "auth":   : "snowflake | externalbrowser | <okta-url>"
       // if using "auth": "snowflake", provide a password
+      // you can alternatively set SNOWSQL_PWD in you environment instead
       // if using "auth": "externalbrowser" or "<okta-url>", no password needed
       "password": "pwd"
     }

--- a/SQLToolsConnections.sublime-settings
+++ b/SQLToolsConnections.sublime-settings
@@ -88,10 +88,12 @@
       "database": "database",
       // for possible authentication configurations see
       // https://docs.snowflake.net/manuals/user-guide/snowsql-start.html#authenticator
-      // if using "snowflake", need to set SNOWSQL_PWD environment variable
       "user"    : "user@example.com",
       "account" : "account_name",
       "auth":   : "snowflake | externalbrowser | <okta-url>"
+      // if using "auth": "snowflake", provide a password
+      // if using "auth": "externalbrowser" or "<okta-url>", no password needed
+      "password": "pwd"
     }
   */
   },

--- a/SQLToolsConnections.sublime-settings
+++ b/SQLToolsConnections.sublime-settings
@@ -82,6 +82,16 @@
       // note the forward slashes (if path is used)
       "database": "c:/firebird/examples/empbuild/employee.fdb",
       "encoding": "utf-8"
+    },
+    "Connection Snowflake": {
+      "type"    : "snowsql",
+      "database": "database",
+      // for possible authentication configurations see
+      // https://docs.snowflake.net/manuals/user-guide/snowsql-start.html#authenticator
+      // if using "snowflake", need to set SNOWSQL_PWD environment variable
+      "user"    : "user@example.com",
+      "account" : "account_name",
+      "auth":   : "snowflake | externalbrowser | <okta-url>"
     }
   */
   },


### PR DESCRIPTION
I've added support for [Snowflake's `snowsql` CLI](https://docs.snowflake.net/manuals/user-guide/snowsql-start.html). 

`execute`, `show records`, `desc`, `desc table`, and `columns` all implemented, but Snowflake doesn't yet have an `explain` equivalent for `snowsql` yet. 

Included an example configuration with instructions on configuring with either single sign-on or simple Snowflake auth.