### PR TITLE
 Add a setting to disable completion for selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ SQLTools will save you (for sure) a lot of time and help you to increase your pr
 
 ## Features
 
-* Works with PostgreSQL, MySQL, Oracle, MSSQL, SQLite, Vertica, Firebird
+* Works with PostgreSQL, MySQL, Oracle, MSSQL, SQLite, Vertica, Firebird, and Snowflake
 * Smart completions (except SQLite)
 * Run SQL Queries &nbsp; <kbd>CTRL+e</kbd>, <kbd>CTRL+e</kbd>
 ![Auto complete and run SQL queries](https://github.com/mtxr/SQLTools/raw/images/execute_auto_complete.gif?raw=true)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ SQLTools will save you (for sure) a lot of time and help you to increase your pr
 
 ## Features
 
-* Works with PostgreSQL, MySQL, Oracle, MSSQL, SQLite, Vertica, Firebird, and Snowflake
+* Works with PostgreSQL, MySQL, Oracle, MSSQL, SQLite, Vertica, Firebird and Snowflake
 * Smart completions (except SQLite)
 * Run SQL Queries &nbsp; <kbd>CTRL+e</kbd>, <kbd>CTRL+e</kbd>
 ![Auto complete and run SQL queries](https://github.com/mtxr/SQLTools/raw/images/execute_auto_complete.gif?raw=true)

--- a/SQLTools.py
+++ b/SQLTools.py
@@ -437,9 +437,13 @@ class ST(EventListener):
         if not len(locations):
             return None
 
-        # disable completions inside strings
-        if view.match_selector(locations[0], 'string'):
-            return None
+        # disable completions for specific selectors
+        # disabled_for_selectors = ST.completion.selectors()
+        disabled_for_selectors = ['string.quoted.single.sql', 'string.quoted.single.pgsql']
+        if disabled_for_selectors:
+            for selector in disabled_for_selectors:
+                if view.match_selector(locations[0], selector):
+                    return None
 
         # show completions only for specific selectors
         selectors = ST.completion.getSelectors()
@@ -450,8 +454,8 @@ class ST(EventListener):
                     selectorMatched = True
                     break
 
-        if not selectorMatched:
-            return None
+            if not selectorMatched:
+                return None
 
         # sublimePrefix = prefix
         # sublimeCompletions = view.extract_completions(sublimePrefix, locations[0])

--- a/SQLTools.py
+++ b/SQLTools.py
@@ -74,14 +74,14 @@ def startPlugin():
         settings    = Settings(SETTINGS_FILENAME, default=SETTINGS_FILENAME_DEFAULT)
     except Exception as e:
         msg = '{0}: Failed to parse {1} file'.format(__package__, SQLTOOLS_SETTINGS_FILE)
-        logging.error(msg + "\nError: " + str(e))
+        logging.exception(msg)
         Window().status_message(msg)
 
     try:
         connections = Settings(CONNECTIONS_FILENAME, default=CONNECTIONS_FILENAME_DEFAULT)
     except Exception as e:
         msg = '{0}: Failed to parse {1} file'.format(__package__, SQLTOOLS_CONNECTIONS_FILE)
-        logging.error(msg + "\nError: " + str(e))
+        logging.exception(msg)
         Window().status_message(msg)
 
     queries     = Storage(QUERIES_FILENAME, default=QUERIES_FILENAME_DEFAULT)

--- a/SQLTools.py
+++ b/SQLTools.py
@@ -437,24 +437,18 @@ class ST(EventListener):
         if not len(locations):
             return None
 
-        # disable completions for specific selectors
-        # disabled_for_selectors = ST.completion.selectors()
-        disabled_for_selectors = ['string.quoted.single.sql', 'string.quoted.single.pgsql']
-        if disabled_for_selectors:
-            for selector in disabled_for_selectors:
+        ignoreSelectors = ST.completion.getIgnoreSelectors()
+        if ignoreSelectors:
+            for selector in ignoreSelectors:
                 if view.match_selector(locations[0], selector):
                     return None
 
-        # show completions only for specific selectors
-        selectors = ST.completion.getSelectors()
-        selectorMatched = False
-        if selectors:
-            for selector in selectors:
+        activeSelectors = ST.completion.getActiveSelectors()
+        if activeSelectors:
+            for selector in activeSelectors:
                 if view.match_selector(locations[0], selector):
-                    selectorMatched = True
                     break
-
-            if not selectorMatched:
+            else:
                 return None
 
         # sublimePrefix = prefix

--- a/SQLTools.py
+++ b/SQLTools.py
@@ -767,16 +767,6 @@ def reload():
 
 
 def plugin_loaded():
-    # this ensures we have empty settings file in 'User' directory during first start
-    # otherwise sublime will copy entire contents of 'SQLTools.sublime-settings'
-    # which is not desirable and prevents future changes to queries and other
-    # sensible defaults defined in settings file, as those would be overridden by content
-    # from older versions of SQLTools in 'User\SQLTools.sublime-settings'
-    sublimeUserFolder = getSublimeUserFolder()
-    userSettingFile = os.path.join(sublimeUserFolder, SQLTOOLS_SETTINGS_FILE)
-    if not os.path.isfile(userSettingFile):
-        # create empty settings file in 'User' folder
-        sublime.save_settings(SQLTOOLS_SETTINGS_FILE)
 
     try:
         from package_control import events

--- a/SQLTools.sublime-settings
+++ b/SQLTools.sublime-settings
@@ -87,15 +87,26 @@
     },
 
     /**
-     * The list of syntax selectors for which the plugin autocompletion will be active.
+     * The list of syntax selectors for which the autocompletion will be active.
      * An empty list means autocompletion always active.
      */
-    "selectors": [
+    "autocomplete_selectors_active": [
         "source.sql",
         "source.pgsql",
         "source.plpgsql.postgres",
         "source.plsql.oracle",
         "source.tsql"
+    ],
+
+    /**
+     * The list of syntax selectors for which the autocompletion will be disabled.
+     */
+    "autocomplete_selectors_ignore": [
+        "string.quoted.single.sql",
+        "string.quoted.single.pgsql",
+        "string.quoted.single.postgres",
+        "string.quoted.single.oracle",
+        "string.group.quote.oracle"
     ],
 
     /**

--- a/SQLTools.sublime-settings
+++ b/SQLTools.sublime-settings
@@ -15,7 +15,8 @@
         "sqlite"  : "sqlite3",
         "vertica" : "vsql",
         "firebird": "isql",
-        "sqsh"    : "sqsh"
+        "sqsh"    : "sqsh",
+        "snowsql" : "snowsql"
     },
 
     // If there is no SQL selected, use "expanded" region.
@@ -509,6 +510,36 @@
                     "query": "select top {1} * from \"{0}\";",
                     "options": [],
                     "before": ["\\set semicolon_cmd=\"\\go -mpretty -l\""]
+                }
+            }
+        },
+
+        "snowsql": {
+            "options": [],
+            "args": "-u {user} -a {account} -d {database} --authenticator {auth} -K",
+            "queries": {
+                "execute": {
+                    "options": [],
+                },
+                "show records": {
+                    "query": "SELECT * FROM {0} LIMIT {1};"
+                },
+                "desc table": {
+                    "query": "DESC TABLE {0};",
+                    "options": ["-o", "output_format=plain", 
+                                "-o", "timing=False"]
+                },
+                "desc": {
+                    "query": "SELECT TABLE_SCHEMA || '.' || TABLE_NAME AS tbl FROM INFORMATION_SCHEMA.TABLES;",
+                    "options": ["-o", "output_format=plain", 
+                                "-o", "header=False", 
+                                "-o", "timing=False"]
+                },
+                "columns": {
+                    "query": "SELECT TABLE_NAME || '.' || COLUMN_NAME AS col FROM INFORMATION_SCHEMA.COLUMNS",
+                    "options": ["-o", "output_format=plain", 
+                                "-o", "header=False", 
+                                "-o", "timing=False"]
                 }
             }
         }

--- a/SQLTools.sublime-settings
+++ b/SQLTools.sublime-settings
@@ -516,6 +516,9 @@
 
         "snowsql": {
             "options": [],
+            "env_optional": {
+                "SNOWSQL_PWD": "{password}"
+            },
             "args": "-u {user} -a {account} -d {database} --authenticator {auth} -K",
             "queries": {
                 "execute": {

--- a/SQLTools.sublime-settings
+++ b/SQLTools.sublime-settings
@@ -530,13 +530,13 @@
                                 "-o", "timing=False"]
                 },
                 "desc": {
-                    "query": "SELECT TABLE_SCHEMA || '.' || TABLE_NAME AS tbl FROM INFORMATION_SCHEMA.TABLES;",
+                    "query": "SELECT TABLE_SCHEMA || '.' || TABLE_NAME AS tbl FROM INFORMATION_SCHEMA.TABLES ORDER BY tbl;",
                     "options": ["-o", "output_format=plain", 
                                 "-o", "header=False", 
                                 "-o", "timing=False"]
                 },
                 "columns": {
-                    "query": "SELECT TABLE_NAME || '.' || COLUMN_NAME AS col FROM INFORMATION_SCHEMA.COLUMNS",
+                    "query": "SELECT TABLE_NAME || '.' || COLUMN_NAME AS col FROM INFORMATION_SCHEMA.COLUMNS ORDER BY col;",
                     "options": ["-o", "output_format=plain", 
                                 "-o", "header=False", 
                                 "-o", "timing=False"]

--- a/SQLToolsAPI/Completion.py
+++ b/SQLToolsAPI/Completion.py
@@ -172,8 +172,17 @@ class Completion:
         if settings is None:
             settings = {}
 
-        # get completion selectors from settings
-        self.selectors = settings.get('selectors', [])
+        # check old setting name ('selectors') first for compatibility
+        activeSelectors = settings.get('selectors', None)
+        if not activeSelectors:
+            activeSelectors = settings.get(
+                'autocomplete_selectors_active',
+                ['source.sql'])
+        self.activeSelectors = activeSelectors
+
+        self.ignoreSelectors = settings.get(
+            'autocomplete_selectors_ignore',
+            ['string.quoted.single.sql'])
 
         # determine type of completions
         self.completionType = settings.get('autocompletion', 'smart')
@@ -198,8 +207,11 @@ class Completion:
 
             self.allKeywords.append(CompletionItem('Keyword', keyword))
 
-    def getSelectors(self):
-        return self.selectors
+    def getActiveSelectors(self):
+        return self.activeSelectors
+
+    def getIgnoreSelectors(self):
+        return self.ignoreSelectors
 
     def isDisabled(self):
         return self.completionType is None

--- a/SQLToolsAPI/Storage.py
+++ b/SQLToolsAPI/Storage.py
@@ -12,13 +12,18 @@ class Storage:
         self.items = {}
 
         # copy entire file, to keep comments
-        if not os.path.isfile(filename) and default and os.path.isfile(default):
-            shutil.copyfile(default, filename)
+        # if not os.path.isfile(filename) and default and os.path.isfile(default):
+        #     shutil.copyfile(default, filename)
 
         self.all()
 
     def all(self):
-        self.items = U.parseJson(self.getFilename())
+        userFile = self.getFilename()
+
+        if os.path.exists(userFile):
+            self.items = U.parseJson(self.getFilename())
+        else:
+            self.items = {}
 
         return U.merge(self.items, self.defaults())
 

--- a/SQLToolsConnections.sublime-settings
+++ b/SQLToolsConnections.sublime-settings
@@ -92,6 +92,7 @@
       "account" : "account_name",
       "auth":   : "snowflake | externalbrowser | <okta-url>"
       // if using "auth": "snowflake", provide a password
+      // you can alternatively set SNOWSQL_PWD in you environment instead
       // if using "auth": "externalbrowser" or "<okta-url>", no password needed
       "password": "pwd"
     }

--- a/SQLToolsConnections.sublime-settings
+++ b/SQLToolsConnections.sublime-settings
@@ -88,10 +88,12 @@
       "database": "database",
       // for possible authentication configurations see
       // https://docs.snowflake.net/manuals/user-guide/snowsql-start.html#authenticator
-      // if using "snowflake", need to set SNOWSQL_PWD environment variable
       "user"    : "user@example.com",
       "account" : "account_name",
       "auth":   : "snowflake | externalbrowser | <okta-url>"
+      // if using "auth": "snowflake", provide a password
+      // if using "auth": "externalbrowser" or "<okta-url>", no password needed
+      "password": "pwd"
     }
   */
   },

--- a/SQLToolsConnections.sublime-settings
+++ b/SQLToolsConnections.sublime-settings
@@ -90,7 +90,7 @@
       // https://docs.snowflake.net/manuals/user-guide/snowsql-start.html#authenticator
       "user"    : "user@example.com",
       "account" : "account_name",
-      "auth":   : "snowflake | externalbrowser | <okta-url>"
+      "auth":   : "snowflake | externalbrowser | <okta-url>",
       // if using "auth": "snowflake", provide a password
       // you can alternatively set SNOWSQL_PWD in you environment instead
       // if using "auth": "externalbrowser" or "<okta-url>", no password needed

--- a/SQLToolsConnections.sublime-settings
+++ b/SQLToolsConnections.sublime-settings
@@ -82,6 +82,16 @@
       // note the forward slashes (if path is used)
       "database": "c:/firebird/examples/empbuild/employee.fdb",
       "encoding": "utf-8"
+    },
+    "Connection Snowflake": {
+      "type"    : "snowsql",
+      "database": "database",
+      // for possible authentication configurations see
+      // https://docs.snowflake.net/manuals/user-guide/snowsql-start.html#authenticator
+      // if using "snowflake", need to set SNOWSQL_PWD environment variable
+      "user"    : "user@example.com",
+      "account" : "account_name",
+      "auth":   : "snowflake | externalbrowser | <okta-url>"
     }
   */
   },


### PR DESCRIPTION
Add a setting to disable completion for certain selectors instead of hard-coding them.
This should fix (enable) completions for SQL code embedded as a string in other languages.
Fixes #199 
