### PR TITLE
Release v0.9.12

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.9.9
+current_version = 0.9.12
 files = SQLTools.py
 tag = True
 commit = True

--- a/SQLTools.py
+++ b/SQLTools.py
@@ -1,4 +1,4 @@
-__version__ = "v0.9.9"
+__version__ = "v0.9.12"
 
 import sys
 import os

--- a/messages.json
+++ b/messages.json
@@ -14,5 +14,8 @@
     "0.9.6": "messages/v0.9.6.md",
     "0.9.7": "messages/v0.9.7.md",
     "0.9.8": "messages/v0.9.8.md",
-    "0.9.9": "messages/v0.9.9.md"
+    "0.9.9": "messages/v0.9.9.md",
+    "0.9.10": "messages/v0.9.10.md",
+    "0.9.11": "messages/v0.9.11.md",
+    "0.9.12": "messages/v0.9.12.md"
 }

--- a/messages/v0.9.10.md
+++ b/messages/v0.9.10.md
@@ -1,0 +1,5 @@
+## v0.9.10 Notes
+
+### Fixes
+
+* Added `focus_result` setting closing issue [#183]

--- a/messages/v0.9.11.md
+++ b/messages/v0.9.11.md
@@ -1,0 +1,5 @@
+## v0.9.11 Notes
+
+### Fixes
+
+* New command `ST: Format SQL All File` (internal name `st_format_all`) to format the entire file [#182]

--- a/messages/v0.9.12.md
+++ b/messages/v0.9.12.md
@@ -1,0 +1,18 @@
+## v0.9.12 Notes
+
+### Improvements
+
+* Snowflake (`snowsql`) support
+* Added support for prompting of the connection parameters
+* Table/view/function selection quick panel is pre-populated with the text of the current selection
+* New command `ST: Refresh Connection Data` (internal name `st_refresh_connection_data`) to reload the list of database objects
+* Improve performance (completions and connection listing)
+* Add a configurable setting to enable/disable completion for certain selectors (`autocomplete_selectors_ignore`, `autocomplete_selectors_active`)
+
+
+### Fixes
+
+* Fix PostgreSQL v11 compatibility issue (functions were not listed)
+* Do not create an empty settings file [#144]
+* Bump timeout to 60 seconds for internal commands
+* Use python core logging for logs


### PR DESCRIPTION
### Improvements

* Snowflake (`snowsql`) support
* Added support for prompting of the connection parameters
* Table/view/function selection quick panel is pre-populated with the text of the current selection
* New command `ST: Refresh Connection Data` (internal name `st_refresh_connection_data`) to reload the list of database objects
* Improve performance (completions and connection listing)
* Add a configurable setting to enable/disable completion for certain selectors (`autocomplete_selectors_ignore`, `autocomplete_selectors_active`)


### Fixes

* Fix PostgreSQL v11 compatibility issue (functions were not listed)
* Do not create an empty settings file [#144]
* Bump timeout to 60 seconds for internal commands
* Use python core logging for logs
